### PR TITLE
CGBA-40 Prototype sync endpoint degrading to async on timeout

### DIFF
--- a/app/connectors/BalanceRequestConnector.scala
+++ b/app/connectors/BalanceRequestConnector.scala
@@ -19,14 +19,18 @@ package connectors
 import cats.effect.IO
 import com.google.inject.ImplementedBy
 import config.AppConfig
+import models.backend.BalanceRequestResponse
 import models.request.BalanceRequest
 import models.values.BalanceId
 import play.api.http.ContentTypes
 import play.api.http.HeaderNames
+import play.api.http.Status
 import runtime.IOFutures
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpClient
+import uk.gov.hmrc.http.HttpReads
 import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import javax.inject.Inject
@@ -36,7 +40,7 @@ import javax.inject.Singleton
 trait BalanceRequestConnector {
   def sendRequest(request: BalanceRequest)(implicit
     hc: HeaderCarrier
-  ): IO[Either[UpstreamErrorResponse, BalanceId]]
+  ): IO[Either[UpstreamErrorResponse, Either[BalanceId, BalanceRequestResponse]]]
 }
 
 @Singleton
@@ -44,16 +48,32 @@ class BalanceRequestConnectorImpl @Inject() (appConfig: AppConfig, http: HttpCli
     extends BalanceRequestConnector
     with IOFutures {
 
+  implicit val eitherBalanceIdOrResponseReads
+    : HttpReads[Either[BalanceId, BalanceRequestResponse]] =
+    HttpReads[HttpResponse].map { response =>
+      response.status match {
+        case Status.ACCEPTED =>
+          Left(response.json.as[BalanceId])
+        case Status.OK =>
+          Right(response.json.as[BalanceRequestResponse])
+      }
+    }
+
   def sendRequest(request: BalanceRequest)(implicit
     hc: HeaderCarrier
-  ): IO[Either[UpstreamErrorResponse, BalanceId]] =
+  ): IO[Either[UpstreamErrorResponse, Either[BalanceId, BalanceRequestResponse]]] =
     IO.runFuture { implicit ec =>
       val url = appConfig.backendUrl.addPathPart("balances")
+
       val headers = Seq(
         HeaderNames.ACCEPT       -> ContentTypes.JSON,
         HeaderNames.CONTENT_TYPE -> ContentTypes.JSON
       )
-      http.POST[BalanceRequest, Either[UpstreamErrorResponse, BalanceId]](
+
+      http.POST[BalanceRequest, Either[
+        UpstreamErrorResponse,
+        Either[BalanceId, BalanceRequestResponse]
+      ]](
         url.toString,
         request,
         headers

--- a/app/connectors/BalanceRequestConnector.scala
+++ b/app/connectors/BalanceRequestConnector.scala
@@ -19,8 +19,10 @@ package connectors
 import cats.effect.IO
 import com.google.inject.ImplementedBy
 import config.AppConfig
+import config.Constants
 import models.backend.BalanceRequestResponse
 import models.request.BalanceRequest
+import models.request.Channel
 import models.values.BalanceId
 import play.api.http.ContentTypes
 import play.api.http.HeaderNames
@@ -67,7 +69,8 @@ class BalanceRequestConnectorImpl @Inject() (appConfig: AppConfig, http: HttpCli
 
       val headers = Seq(
         HeaderNames.ACCEPT       -> ContentTypes.JSON,
-        HeaderNames.CONTENT_TYPE -> ContentTypes.JSON
+        HeaderNames.CONTENT_TYPE -> ContentTypes.JSON,
+        Constants.ChannelHeader  -> Channel.Api.name
       )
 
       http.POST[BalanceRequest, Either[

--- a/app/models/backend/BalanceRequestResponse.scala
+++ b/app/models/backend/BalanceRequestResponse.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.backend
+
+import cats.data.NonEmptyList
+import models.backend.errors.FunctionalError
+import models.formats.CommonFormats
+import models.values.CurrencyCode
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+import uk.gov.hmrc.play.json.Union
+
+sealed abstract class BalanceRequestResponse extends Product with Serializable
+
+case class BalanceRequestSuccess(
+  balance: BigDecimal,
+  currency: CurrencyCode
+) extends BalanceRequestResponse
+
+case class BalanceRequestFunctionalError(
+  errors: NonEmptyList[FunctionalError]
+) extends BalanceRequestResponse
+
+object BalanceRequestResponse extends CommonFormats {
+  implicit lazy val balanceRequestSuccessFormat: OFormat[BalanceRequestSuccess] =
+    Json.format[BalanceRequestSuccess]
+
+  implicit lazy val balanceRequestFunctionalErrorFormat: OFormat[BalanceRequestFunctionalError] =
+    Json.format[BalanceRequestFunctionalError]
+
+  implicit lazy val balanceRequestResponseFormat: OFormat[BalanceRequestResponse] =
+    Union
+      .from[BalanceRequestResponse](BalanceRequestResponseStatus.FieldName)
+      .and[BalanceRequestSuccess](BalanceRequestResponseStatus.Success)
+      .and[BalanceRequestFunctionalError](BalanceRequestResponseStatus.FunctionalError)
+      .format
+}

--- a/app/models/backend/BalanceRequestResponseStatus.scala
+++ b/app/models/backend/BalanceRequestResponseStatus.scala
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-package models.errors
+package models.backend
 
-/** Common error codes documented in [[https://developer.service.hmrc.gov.uk/api-documentation/docs/reference-guide#errors Developer Hub Reference Guide]]
-  */
-object ErrorCode {
-  val FieldName           = "code"
-  val BadRequest          = "BAD_REQUEST"
-  val InternalServerError = "INTERNAL_SERVER_ERROR"
-  val FunctionalError     = "FUNCTIONAL_ERROR"
+object BalanceRequestResponseStatus {
+  val FieldName       = "status"
+  val Success         = "SUCCESS"
+  val FunctionalError = "FUNCTIONAL_ERROR"
 }

--- a/app/models/backend/errors/FunctionalError.scala
+++ b/app/models/backend/errors/FunctionalError.scala
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-package models.errors
+package models.backend.errors
 
-/** Common error codes documented in [[https://developer.service.hmrc.gov.uk/api-documentation/docs/reference-guide#errors Developer Hub Reference Guide]]
-  */
-object ErrorCode {
-  val FieldName           = "code"
-  val BadRequest          = "BAD_REQUEST"
-  val InternalServerError = "INTERNAL_SERVER_ERROR"
-  val FunctionalError     = "FUNCTIONAL_ERROR"
+import models.values.ErrorType
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+case class FunctionalError(
+  errorType: ErrorType,
+  errorPointer: String,
+  errorReason: Option[String]
+)
+
+object FunctionalError {
+  implicit lazy val functionalErrorFormat: OFormat[FunctionalError] =
+    Json.format[FunctionalError]
 }

--- a/app/models/errors/BalanceRequestError.scala
+++ b/app/models/errors/BalanceRequestError.scala
@@ -27,6 +27,8 @@ sealed abstract class BalanceRequestError extends Product with Serializable {
 case class UpstreamServiceError(message: String = "Internal server error")
     extends BalanceRequestError
 
+case class UpstreamTimeoutError(message: String = "Request timed out") extends BalanceRequestError
+
 case class InternalServiceError(message: String = "Internal server error")
     extends BalanceRequestError
 
@@ -43,10 +45,14 @@ object BalanceRequestError {
   implicit def internalServiceErrorFormat: OFormat[InternalServiceError] =
     Json.format[InternalServiceError]
 
+  implicit def upstreamTimeoutErrorFormat: OFormat[UpstreamTimeoutError] =
+    Json.format[UpstreamTimeoutError]
+
   implicit def balanceRequestErrorFormat: OFormat[BalanceRequestError] =
     Union
       .from[BalanceRequestError](ErrorCode.FieldName)
       .and[UpstreamServiceError](ErrorCode.InternalServerError)
+      .and[UpstreamTimeoutError](ErrorCode.GatewayTimeout)
       .and[InternalServiceError](ErrorCode.InternalServerError)
       .format
 }

--- a/app/models/errors/BalanceRequestError.scala
+++ b/app/models/errors/BalanceRequestError.scala
@@ -21,29 +21,21 @@ import play.api.libs.json.OFormat
 import uk.gov.hmrc.play.json.Union
 
 sealed abstract class BalanceRequestError extends Product with Serializable {
-  def statusCode: Int
   def message: String
 }
 
-case class BadRequestError(
-  message: String,
-  errors: List[BalanceRequestError] = List.empty
-) extends BalanceRequestError {
-  def statusCode: Int = 400
-}
-
 case class UpstreamServiceError(message: String = "Internal server error")
-    extends BalanceRequestError {
-  def statusCode: Int = 500
-}
+    extends BalanceRequestError
+
 case class InternalServiceError(message: String = "Internal server error")
-    extends BalanceRequestError {
-  def statusCode: Int = 500
-}
+    extends BalanceRequestError
 
 object BalanceRequestError {
-  implicit def badRequestErrorFormat: OFormat[BadRequestError] =
-    Json.format[BadRequestError]
+  def upstreamServiceError(message: String = "Internal server error"): BalanceRequestError =
+    UpstreamServiceError(message)
+
+  def internalServiceError(message: String = "Internal server error"): BalanceRequestError =
+    InternalServiceError(message)
 
   implicit def upstreamServiceErrorFormat: OFormat[UpstreamServiceError] =
     Json.format[UpstreamServiceError]
@@ -54,7 +46,6 @@ object BalanceRequestError {
   implicit def balanceRequestErrorFormat: OFormat[BalanceRequestError] =
     Union
       .from[BalanceRequestError](ErrorCode.FieldName)
-      .andLazy[BadRequestError](ErrorCode.BadRequest, badRequestErrorFormat)
       .and[UpstreamServiceError](ErrorCode.InternalServerError)
       .and[InternalServiceError](ErrorCode.InternalServerError)
       .format

--- a/app/models/errors/ErrorCode.scala
+++ b/app/models/errors/ErrorCode.scala
@@ -22,5 +22,6 @@ object ErrorCode {
   val FieldName           = "code"
   val BadRequest          = "BAD_REQUEST"
   val InternalServerError = "INTERNAL_SERVER_ERROR"
+  val GatewayTimeout      = "GATEWAY_TIMEOUT"
   val FunctionalError     = "FUNCTIONAL_ERROR"
 }

--- a/app/models/request/Channel.scala
+++ b/app/models/request/Channel.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package config
+package models.request
 
-object Constants {
-  val Context       = "/customs/guarantees"
-  val ChannelHeader = "Channel"
+sealed abstract class Channel(val name: String) extends Product with Serializable
+
+object Channel {
+  case object Api extends Channel("api")
 }

--- a/it/connectors/BalanceRequestConnectorSpec.scala
+++ b/it/connectors/BalanceRequestConnectorSpec.scala
@@ -70,6 +70,7 @@ class BalanceRequestConnectorSpec
       post(urlEqualTo("/transit-movements-guarantee-balance/balances"))
         .withHeader(HeaderNames.ACCEPT, equalTo(ContentTypes.JSON))
         .withHeader(HeaderNames.CONTENT_TYPE, equalTo(ContentTypes.JSON))
+        .withHeader("Channel", equalTo("api"))
         .withRequestBody(equalToJson(Json.stringify(requestJson)))
         .willReturn(
           aResponse()
@@ -104,6 +105,7 @@ class BalanceRequestConnectorSpec
       post(urlEqualTo("/transit-movements-guarantee-balance/balances"))
         .withHeader(HeaderNames.ACCEPT, equalTo(ContentTypes.JSON))
         .withHeader(HeaderNames.CONTENT_TYPE, equalTo(ContentTypes.JSON))
+        .withHeader("Channel", equalTo("api"))
         .withRequestBody(equalToJson(Json.stringify(requestJson)))
         .willReturn(
           aResponse()

--- a/public/api/conf/1.0/application.raml
+++ b/public/api/conf/1.0/application.raml
@@ -63,24 +63,24 @@ traits:
                   "currency": "GBP"
                 }
               }
-      202:
-        headers:
-          Location:
-            description: The path of the newly created balance request
-            type: string
-            example: "/customs/guarantees/balances/22b9899e-24ee-48e6-a189-97d1f45391c4"
-        body:
-          application/json:
-            type: !include schemas/post-balance-request-pending-response-schema.json
-            example: |
-              {
-                "_links": {
-                  "self": {
-                    "href": "/customs/guarantees/balances/22b9899e-24ee-48e6-a189-97d1f45391c4"
-                  }
-                },
-                "balanceId": "22b9899e-24ee-48e6-a189-97d1f45391c4"
-              }
+      # 202:
+      #   headers:
+      #     Location:
+      #       description: The path of the newly created balance request
+      #       type: string
+      #       example: "/customs/guarantees/balances/22b9899e-24ee-48e6-a189-97d1f45391c4"
+      #   body:
+      #     application/json:
+      #       type: !include schemas/post-balance-request-pending-response-schema.json
+      #       example: |
+      #         {
+      #           "_links": {
+      #             "self": {
+      #               "href": "/customs/guarantees/balances/22b9899e-24ee-48e6-a189-97d1f45391c4"
+      #             }
+      #           },
+      #           "balanceId": "22b9899e-24ee-48e6-a189-97d1f45391c4"
+      #         }
       400:
         body:
           application/json:

--- a/public/api/conf/1.0/application.raml
+++ b/public/api/conf/1.0/application.raml
@@ -52,6 +52,17 @@ traits:
             "accessCode": "ABC1"
           }
     responses:
+      200:
+        body:
+          application/json:
+            type: !include schemas/post-balance-request-success-response-schema.json
+            example: |
+              {
+                "response": {
+                  "balance": 12345678.9,
+                  "currency": "GBP"
+                }
+              }
       202:
         headers:
           Location:
@@ -60,7 +71,7 @@ traits:
             example: "/customs/guarantees/balances/22b9899e-24ee-48e6-a189-97d1f45391c4"
         body:
           application/json:
-            type: !include schemas/post-balance-request-response-schema.json
+            type: !include schemas/post-balance-request-pending-response-schema.json
             example: |
               {
                 "_links": {
@@ -70,6 +81,23 @@ traits:
                 },
                 "balanceId": "22b9899e-24ee-48e6-a189-97d1f45391c4"
               }
+      400:
+        body:
+          application/json:
+            type: !include schemas/post-balance-request-functional-error-response-schema.json
+            description: The request was rejected by the guarantee management system
+            example: |
+              {
+                "code": "FUNCTIONAL_ERROR",
+                "message": "The request was rejected by the guarantee management system",
+                "response": {
+                  "errors": [{
+                    "errorType": 14,
+                    "errorPointer": "Foo.Bar(1).Baz"
+                  }]
+                }
+              }
+
 
   /{balanceId}:
     uriParameters:

--- a/public/api/conf/1.0/schemas/balance-request-functional-error-schema.json
+++ b/public/api/conf/1.0/schemas/balance-request-functional-error-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "#/balance-request-functional-error-schema.json",
-    "description": "A functional error response from the CTC Guarantee Balance API",
+    "description": "A functional error response from the guarantee management system",
     "type": "object",
     "definitions": {
         "functionalError": {

--- a/public/api/conf/1.0/schemas/balance-request-functional-error-schema.json
+++ b/public/api/conf/1.0/schemas/balance-request-functional-error-schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "#/balance-request-functional-error-schema.json",
+    "description": "A functional error response from the CTC Guarantee Balance API",
+    "type": "object",
+    "definitions": {
+        "functionalError": {
+            "description": "A functional error",
+            "type": "object",
+            "required": [
+                "errorType",
+                "errorPointer"
+            ],
+            "properties": {
+                "errorType": {
+                    "type": "number",
+                    "description": "The numeric error code of the functional error"
+                },
+                "errorPointer": {
+                    "type": "string",
+                    "description": "The pointer string indicating the data item that was in error"
+                },
+                "errorReason": {
+                    "type": "string",
+                    "description": "The reason message indicating additional information about the cause of the error"
+                }
+            }
+        }
+    },
+    "required": [
+        "errors"
+    ],
+    "properties": {
+        "errors": {
+            "type": "array",
+            "description": "The functional errors returned when attempting to make the balance request",
+            "items": {
+                "$ref": "#/definitions/functionalError"
+            }
+        }
+    }
+}

--- a/public/api/conf/1.0/schemas/balance-request-success-schema.json
+++ b/public/api/conf/1.0/schemas/balance-request-success-schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "#/balance-request-success-schema.json",
+    "description": "A successful balance request response from the CTC Guarantee Balance API",
+    "type": "object",
+    "required": [
+        "balance",
+        "currency"
+    ],
+    "properties": {
+        "balance": {
+            "type": "number",
+            "description": "The remaining guarantee balance"
+        },
+        "currency": {
+            "type": "string",
+            "description": "The alphanumeric 3-character ISO currency code of the currency in which the balance is held",
+            "pattern": "^[A-Z]{3}$"
+        }
+    }
+}

--- a/public/api/conf/1.0/schemas/balance-request-success-schema.json
+++ b/public/api/conf/1.0/schemas/balance-request-success-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "#/balance-request-success-schema.json",
-    "description": "A successful balance request response from the CTC Guarantee Balance API",
+    "description": "A successful response from the guarantee management system",
     "type": "object",
     "required": [
         "balance",

--- a/public/api/conf/1.0/schemas/post-balance-request-functional-error-response-schema.json
+++ b/public/api/conf/1.0/schemas/post-balance-request-functional-error-response-schema.json
@@ -1,12 +1,12 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "#/post-balance-request-response-schema.json",
-    "title": "Balance Request",
-    "description": "A balance request response from the CTC Guarantee Balance API",
+    "$id": "#/post-balance-request-functional-error-response-schema.json",
+    "description": "A functional error response from the CTC Guarantee Balance API",
     "type": "object",
     "required": [
-        "_links",
-        "balanceId"
+        "code",
+        "message",
+        "response"
     ],
     "properties": {
         "_links": {
@@ -23,9 +23,16 @@
                 "$ref": "hal-document-schema.json#"
             }
         },
-        "balanceId": {
-            "description": "The ID of the balance request",
+        "code": {
+            "enum": [
+                "FUNCTIONAL_ERROR"
+            ]
+        },
+        "message": {
             "type": "string"
+        },
+        "response": {
+            "$ref": "balance-request-functional-error-schema.json#"
         }
     }
 }

--- a/public/api/conf/1.0/schemas/post-balance-request-functional-error-response-schema.json
+++ b/public/api/conf/1.0/schemas/post-balance-request-functional-error-response-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "#/post-balance-request-functional-error-response-schema.json",
-    "description": "A functional error response from the CTC Guarantee Balance API",
+    "description": "A functional error response from the guarantee management system",
     "type": "object",
     "required": [
         "code",
@@ -29,6 +29,7 @@
             ]
         },
         "message": {
+            "description": "The description of the error",
             "type": "string"
         },
         "response": {

--- a/public/api/conf/1.0/schemas/post-balance-request-pending-response-schema.json
+++ b/public/api/conf/1.0/schemas/post-balance-request-pending-response-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "#/post-balance-request-pending-response-schema.json",
-    "description": "A pending balance request response from the CTC Guarantee Balance API",
+    "description": "A pending balance request response",
     "type": "object",
     "required": [
         "_links",

--- a/public/api/conf/1.0/schemas/post-balance-request-pending-response-schema.json
+++ b/public/api/conf/1.0/schemas/post-balance-request-pending-response-schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "#/post-balance-request-pending-response-schema.json",
+    "description": "A pending balance request response from the CTC Guarantee Balance API",
+    "type": "object",
+    "required": [
+        "_links",
+        "balanceId"
+    ],
+    "properties": {
+        "_links": {
+            "description": "An object containing links to other resources",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "hal-document-schema.json#/definitions/halLink"
+            }
+        },
+        "_embedded": {
+            "description": "An object containing embedded resources",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "hal-document-schema.json#"
+            }
+        },
+        "balanceId": {
+            "description": "The ID of the balance request",
+            "type": "string"
+        }
+    }
+}

--- a/public/api/conf/1.0/schemas/post-balance-request-schema.json
+++ b/public/api/conf/1.0/schemas/post-balance-request-schema.json
@@ -1,7 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "#/post-balance-request-schema.json",
-    "title": "Balance Request",
     "description": "A balance request for the CTC Guarantee Balance API",
     "type": "object",
     "required": [

--- a/public/api/conf/1.0/schemas/post-balance-request-success-response-schema.json
+++ b/public/api/conf/1.0/schemas/post-balance-request-success-response-schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "#/post-balance-request-success-response-schema.json",
+    "description": "A successful balance request response from the CTC Guarantee Balance API",
+    "type": "object",
+    "required": [
+        "response"
+    ],
+    "properties": {
+        "_links": {
+            "description": "An object containing links to other resources",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "hal-document-schema.json#/definitions/halLink"
+            }
+        },
+        "_embedded": {
+            "description": "An object containing embedded resources",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "hal-document-schema.json#"
+            }
+        },
+        "response": {
+            "$ref": "balance-request-success-schema.json#"
+        }
+    }
+}

--- a/public/api/conf/1.0/schemas/post-balance-request-success-response-schema.json
+++ b/public/api/conf/1.0/schemas/post-balance-request-success-response-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "#/post-balance-request-success-response-schema.json",
-    "description": "A successful balance request response from the CTC Guarantee Balance API",
+    "description": "A successful balance request response",
     "type": "object",
     "required": [
         "response"

--- a/test/connectors/FakeBalanceRequestConnector.scala
+++ b/test/connectors/FakeBalanceRequestConnector.scala
@@ -17,17 +17,20 @@
 package connectors
 
 import cats.effect.IO
+import models.backend.BalanceRequestResponse
 import models.request.BalanceRequest
 import models.values.BalanceId
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
 
 case class FakeBalanceRequestConnector(
-  sendRequestResponse: IO[Either[UpstreamErrorResponse, BalanceId]] = IO.stub
+  sendRequestResponse: IO[
+    Either[UpstreamErrorResponse, Either[BalanceId, BalanceRequestResponse]]
+  ] = IO.stub
 ) extends BalanceRequestConnector {
 
   override def sendRequest(request: BalanceRequest)(implicit
     hc: HeaderCarrier
-  ): IO[Either[UpstreamErrorResponse, BalanceId]] =
+  ): IO[Either[UpstreamErrorResponse, Either[BalanceId, BalanceRequestResponse]]] =
     sendRequestResponse
 }

--- a/test/controllers/BalanceRequestControllerSpec.scala
+++ b/test/controllers/BalanceRequestControllerSpec.scala
@@ -32,7 +32,6 @@ import models.values._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.http.ContentTypes
-import play.api.http.HeaderNames
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers
@@ -107,7 +106,28 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "return 202 when there is a valid async response" in {
+  // it should "return 202 when there is a valid async response" in {
+  //   val balanceRequest = BalanceRequest(
+  //     TaxIdentifier("GB12345678900"),
+  //     GuaranteeReference("05DE3300BE0001067A001017"),
+  //     AccessCode("1234")
+  //   )
+
+  //   val balanceId = BalanceId(UUID.randomUUID())
+
+  //   val result = controller(
+  //     sendRequestResponse = IO(Right(Left(balanceId)))
+  //   ).submitBalanceRequest(FakeRequest().withBody(balanceRequest))
+
+  //   status(result) shouldBe ACCEPTED
+  //   contentType(result) shouldBe Some(ContentTypes.JSON)
+  //   contentAsJson(result) shouldBe Json.toJson(PostBalanceRequestPendingResponse(balanceId))
+  //   header(HeaderNames.LOCATION, result) shouldBe Some(
+  //     s"/customs/guarantees/balances/${balanceId.value}"
+  //   )
+  // }
+
+  it should "return 504 when the upstream service times out" in {
     val balanceRequest = BalanceRequest(
       TaxIdentifier("GB12345678900"),
       GuaranteeReference("05DE3300BE0001067A001017"),
@@ -120,11 +140,11 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       sendRequestResponse = IO(Right(Left(balanceId)))
     ).submitBalanceRequest(FakeRequest().withBody(balanceRequest))
 
-    status(result) shouldBe ACCEPTED
+    status(result) shouldBe GATEWAY_TIMEOUT
     contentType(result) shouldBe Some(ContentTypes.JSON)
-    contentAsJson(result) shouldBe Json.toJson(PostBalanceRequestPendingResponse(balanceId))
-    header(HeaderNames.LOCATION, result) shouldBe Some(
-      s"/customs/guarantees/balances/${balanceId.value}"
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "GATEWAY_TIMEOUT",
+      "message" -> "Request timed out"
     )
   }
 

--- a/test/models/errors/ErrorFormatsSpec.scala
+++ b/test/models/errors/ErrorFormatsSpec.scala
@@ -38,28 +38,4 @@ class ErrorFormatsSpec extends AnyFlatSpec with Matchers {
       "message" -> "Internal server error"
     )
   }
-
-  it should "produce errors following HMRC Reference Guide for BadRequestError" in {
-    val error = BadRequestError(
-      "Argh!!",
-      List(BadRequestError("I don't like field 1!"), BadRequestError("I don't like field 2!"))
-    )
-    val json = BalanceRequestError.balanceRequestErrorFormat.writes(error)
-    json shouldBe Json.obj(
-      "code"    -> "BAD_REQUEST",
-      "message" -> "Argh!!",
-      "errors" -> Json.arr(
-        Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> "I don't like field 1!",
-          "errors"  -> Json.arr()
-        ),
-        Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> "I don't like field 2!",
-          "errors"  -> Json.arr()
-        )
-      )
-    )
-  }
 }

--- a/test/models/response/ResponseFormatsSpec.scala
+++ b/test/models/response/ResponseFormatsSpec.scala
@@ -77,7 +77,8 @@ class ResponseFormatsSpec extends AnyFlatSpec with Matchers {
       PostBalanceRequestFunctionalErrorResponse(balanceRequestFunctionalError)
 
     Json.toJsObject(response) shouldBe Json.obj(
-      "code" -> "FUNCTIONAL_ERROR",
+      "code"    -> "FUNCTIONAL_ERROR",
+      "message" -> "The request was rejected by the guarantee management system",
       "response" -> Json.obj(
         "errors" -> Json.arr(
           Json.obj(

--- a/test/models/response/ResponseFormatsSpec.scala
+++ b/test/models/response/ResponseFormatsSpec.scala
@@ -16,8 +16,14 @@
 
 package models.response
 
+import cats.data.NonEmptyList
 import controllers.routes.BalanceRequestController
+import models.backend.BalanceRequestFunctionalError
+import models.backend.BalanceRequestSuccess
+import models.backend.errors.FunctionalError
 import models.values.BalanceId
+import models.values.CurrencyCode
+import models.values.ErrorType
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
@@ -34,9 +40,10 @@ class ResponseFormatsSpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  "HalResponse.halResponseWrites" should "write a balance request response" in {
+  "HalResponse.halResponseWrites" should "write a pending balance request response" in {
     val uuid     = UUID.fromString("22b9899e-24ee-48e6-a189-97d1f45391c4")
-    val response = PostBalanceRequestResponse(BalanceId(uuid))
+    val response = PostBalanceRequestPendingResponse(BalanceId(uuid))
+
     Json.toJsObject(response) shouldBe Json.obj(
       "_links" -> Json.obj(
         "self" -> Json.obj(
@@ -44,6 +51,41 @@ class ResponseFormatsSpec extends AnyFlatSpec with Matchers {
         )
       ),
       "balanceId" -> "22b9899e-24ee-48e6-a189-97d1f45391c4"
+    )
+  }
+
+  it should "write a successful balance request response" in {
+    val balanceRequestSuccess =
+      BalanceRequestSuccess(BigDecimal("12345678.90"), CurrencyCode("GBP"))
+    val response =
+      PostBalanceRequestSuccessResponse(balanceRequestSuccess)
+
+    Json.toJsObject(response) shouldBe Json.obj(
+      "response" -> Json.obj(
+        "balance"  -> 12345678.9,
+        "currency" -> "GBP"
+      )
+    )
+  }
+
+  it should "write a functional error response" in {
+    val balanceRequestFunctionalError =
+      BalanceRequestFunctionalError(
+        NonEmptyList.one(FunctionalError(ErrorType(14), "Foo.Bar(1).Baz", None))
+      )
+    val response =
+      PostBalanceRequestFunctionalErrorResponse(balanceRequestFunctionalError)
+
+    Json.toJsObject(response) shouldBe Json.obj(
+      "code" -> "FUNCTIONAL_ERROR",
+      "response" -> Json.obj(
+        "errors" -> Json.arr(
+          Json.obj(
+            "errorType"    -> 14,
+            "errorPointer" -> "Foo.Bar(1).Baz"
+          )
+        )
+      )
     )
   }
 }


### PR DESCRIPTION
My biggest concern about this approach is how the API documentation looks

The RAML renderer does not seem to understand multiple examples with JSON schemas, or render example error responses except as an entry in the Error Scenarios table. 

It renders the JSON schemas as one big table with all of the combined properties of every response, which is discouraging.