### PR TITLE
Fix deserialization bug with XML errors

### DIFF
--- a/app/controllers/BalanceRequestController.scala
+++ b/app/controllers/BalanceRequestController.scala
@@ -49,6 +49,8 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import javax.inject.Inject
 import javax.inject.Singleton
 import scala.util.control.NonFatal
+import models.backend.PendingBalanceRequest
+import models.backend.BalanceRequestXmlError
 
 @Singleton
 class BalanceRequestController @Inject() (
@@ -96,6 +98,9 @@ class BalanceRequestController @Inject() (
               case Right(Right(error @ BalanceRequestFunctionalError(_))) =>
                 BadRequest(Json.toJson(PostBalanceRequestFunctionalErrorResponse(error)))
 
+              case Right(Right(BalanceRequestXmlError(_))) =>
+                InternalServerError(Json.toJson(BalanceRequestError.internalServiceError()))
+
               case Right(Left(balanceId)) =>
                 if (!appConfig.asyncBalanceResponse) {
                   val error     = UpstreamTimeoutError()
@@ -134,6 +139,9 @@ class BalanceRequestController @Inject() (
             .getBalanceRequest(balanceId)
             .flatTap(logServiceError("fetching balance request", _))
             .map {
+              case Right(PendingBalanceRequest(_, _, _, _, _, Some(BalanceRequestXmlError(_)))) =>
+                InternalServerError(Json.toJson(BalanceRequestError.internalServiceError()))
+
               case Right(pendingRequest) =>
                 Ok(Json.toJson(GetBalanceRequestResponse(balanceId, pendingRequest)))
 

--- a/app/models/backend/BalanceRequestResponse.scala
+++ b/app/models/backend/BalanceRequestResponse.scala
@@ -18,6 +18,7 @@ package models.backend
 
 import cats.data.NonEmptyList
 import models.backend.errors.FunctionalError
+import models.backend.errors.XmlError
 import models.formats.CommonFormats
 import models.values.CurrencyCode
 import play.api.libs.json.Json
@@ -35,6 +36,10 @@ case class BalanceRequestFunctionalError(
   errors: NonEmptyList[FunctionalError]
 ) extends BalanceRequestResponse
 
+case class BalanceRequestXmlError(
+  errors: NonEmptyList[XmlError]
+) extends BalanceRequestResponse
+
 object BalanceRequestResponse extends CommonFormats {
   implicit lazy val balanceRequestSuccessFormat: OFormat[BalanceRequestSuccess] =
     Json.format[BalanceRequestSuccess]
@@ -42,10 +47,14 @@ object BalanceRequestResponse extends CommonFormats {
   implicit lazy val balanceRequestFunctionalErrorFormat: OFormat[BalanceRequestFunctionalError] =
     Json.format[BalanceRequestFunctionalError]
 
+  implicit lazy val balanceRequestXmlErrorFormat: OFormat[BalanceRequestXmlError] =
+    Json.format[BalanceRequestXmlError]
+
   implicit lazy val balanceRequestResponseFormat: OFormat[BalanceRequestResponse] =
     Union
       .from[BalanceRequestResponse](BalanceRequestResponseStatus.FieldName)
       .and[BalanceRequestSuccess](BalanceRequestResponseStatus.Success)
       .and[BalanceRequestFunctionalError](BalanceRequestResponseStatus.FunctionalError)
+      .and[BalanceRequestXmlError](BalanceRequestResponseStatus.XmlError)
       .format
 }

--- a/app/models/backend/errors/XmlError.scala
+++ b/app/models/backend/errors/XmlError.scala
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
-package models.backend
+package models.backend.errors
 
-object BalanceRequestResponseStatus {
-  val FieldName       = "status"
-  val Success         = "SUCCESS"
-  val FunctionalError = "FUNCTIONAL_ERROR"
-  val XmlError        = "XML_ERROR"
+import models.values.ErrorType
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+case class XmlError(
+  errorType: ErrorType,
+  errorPointer: String,
+  errorReason: Option[String]
+)
+
+object XmlError {
+  implicit lazy val xmlErrorFormat: OFormat[XmlError] =
+    Json.format[XmlError]
 }


### PR DESCRIPTION
This fixes a funny bug which passed in the acceptance tests because it accidentally leads to the right behaviour.

At the moment the API doesn't know about XML errors, so it was failing to deserialize them when fetching a balance request leading to a 500.

However, since the existence of an XML error indicates a bug in the backend that should not be exposed to users, I think that the API should still return a 500 for a balance request that has received an XML error.