### PR TITLE
Add validation of balance request parameters

### DIFF
--- a/app/controllers/ErrorLogging.scala
+++ b/app/controllers/ErrorLogging.scala
@@ -30,10 +30,10 @@ trait ErrorLogging { self: Logging =>
           logger.error(cause)(s"Error when $action")
         case InternalServiceError(message, None) =>
           logger.error(s"Error when $action: ${message}")
-        case NotFoundError(message) =>
-          logger.error(s"Error when $action: ${message}")
         case UpstreamTimeoutError(message) =>
           logger.error(s"Timed out awaiting upstream response while $action: $message")
+        case NotFoundError(_) =>
+          IO.unit
       },
       _ => IO.unit
     )

--- a/app/models/errors/BadRequestError.scala
+++ b/app/models/errors/BadRequestError.scala
@@ -57,7 +57,7 @@ object BadRequestError extends CommonFormats {
     Json.format[InvalidAccessCode]
 
   implicit val badRequestErrorFormat: Format[BadRequestError] = Union
-    .from[BadRequestError]("code")
+    .from[BadRequestError](ErrorCode.FieldName)
     .and[InvalidTaxIdentifier](ErrorCode.InvalidTaxIdentifier)
     .and[InvalidGuaranteeReference](ErrorCode.InvalidGuaranteeReference)
     .and[InvalidAccessCode](ErrorCode.InvalidAccessCode)

--- a/app/models/errors/BadRequestError.scala
+++ b/app/models/errors/BadRequestError.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.errors
+
+import cats.data.NonEmptyList
+import models.formats.CommonFormats
+import play.api.libs.json.Format
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+import uk.gov.hmrc.play.json.Union
+
+sealed abstract class BadRequestError {
+  def message: String
+}
+
+case class MultipleErrors(message: String = "Bad request", errors: NonEmptyList[BadRequestError])
+  extends BadRequestError
+
+case class InvalidTaxIdentifier(message: String = "Invalid tax identifier value", reason: String)
+  extends BadRequestError
+
+case class InvalidGuaranteeReference(
+  message: String = "Invalid guarantee reference value",
+  reason: String
+) extends BadRequestError
+
+case class InvalidAccessCode(
+  message: String = "Invalid access code value",
+  reason: String
+) extends BadRequestError
+
+object BadRequestError extends CommonFormats {
+  implicit lazy val multipleErrorsFormat: OFormat[MultipleErrors] =
+    Json.format[MultipleErrors]
+
+  implicit val invalidTaxIdentifierFormat: OFormat[InvalidTaxIdentifier] =
+    Json.format[InvalidTaxIdentifier]
+
+  implicit val invalidGuaranteeReferenceFormat: OFormat[InvalidGuaranteeReference] =
+    Json.format[InvalidGuaranteeReference]
+
+  implicit val invalidAccessCodeFormat: OFormat[InvalidAccessCode] =
+    Json.format[InvalidAccessCode]
+
+  implicit val badRequestErrorFormat: Format[BadRequestError] = Union
+    .from[BadRequestError]("code")
+    .and[InvalidTaxIdentifier](ErrorCode.InvalidTaxIdentifier)
+    .and[InvalidGuaranteeReference](ErrorCode.InvalidGuaranteeReference)
+    .and[InvalidAccessCode](ErrorCode.InvalidAccessCode)
+    .andLazy[MultipleErrors](ErrorCode.BadRequest, multipleErrorsFormat)
+    .format
+}

--- a/app/models/errors/BadRequestError.scala
+++ b/app/models/errors/BadRequestError.scala
@@ -33,15 +33,44 @@ case class MultipleErrors(message: String = "Bad request", errors: NonEmptyList[
 case class InvalidTaxIdentifier(message: String = "Invalid tax identifier value", reason: String)
   extends BadRequestError
 
+object InvalidTaxIdentifier {
+  val alphanumeric =
+    InvalidTaxIdentifier(reason = "Tax identifier must be alphanumeric")
+
+  def maxLength(length: Int) =
+    InvalidTaxIdentifier(reason = s"Tax identifier has a maximum length of $length characters")
+}
+
 case class InvalidGuaranteeReference(
   message: String = "Invalid guarantee reference value",
   reason: String
 ) extends BadRequestError
 
+object InvalidGuaranteeReference {
+  val alphanumeric =
+    InvalidGuaranteeReference(reason = "Guarantee reference must be alphanumeric")
+
+  def minLength(length: Int) = InvalidGuaranteeReference(reason =
+    s"Guarantee reference has a minimum length of $length characters"
+  )
+
+  def maxLength(length: Int) = InvalidGuaranteeReference(reason =
+    s"Guarantee reference has a maximum length of $length characters"
+  )
+}
+
 case class InvalidAccessCode(
   message: String = "Invalid access code value",
   reason: String
 ) extends BadRequestError
+
+object InvalidAccessCode {
+  val alphanumeric =
+    InvalidAccessCode(reason = "Access code must be alphanumeric")
+
+  def exactLength(length: Int) =
+    InvalidAccessCode(reason = s"Access code must be $length characters in length")
+}
 
 object BadRequestError extends CommonFormats {
   implicit lazy val multipleErrorsFormat: OFormat[MultipleErrors] =

--- a/app/models/errors/ErrorCode.scala
+++ b/app/models/errors/ErrorCode.scala
@@ -19,11 +19,15 @@ package models.errors
 /** Common error codes documented in [[https://developer.service.hmrc.gov.uk/api-documentation/docs/reference-guide#errors Developer Hub Reference Guide]]
   */
 object ErrorCode {
-  val FieldName           = "code"
-  val BadRequest          = "BAD_REQUEST"
-  val NotFound            = "NOT_FOUND"
-  val InternalServerError = "INTERNAL_SERVER_ERROR"
-  val GatewayTimeout      = "GATEWAY_TIMEOUT"
-  val FunctionalError     = "FUNCTIONAL_ERROR"
-  val AcceptHeaderInvalid = "ACCEPT_HEADER_INVALID"
+  val FieldName                 = "code"
+  val BadRequest                = "BAD_REQUEST"
+  val NotFound                  = "NOT_FOUND"
+  val InternalServerError       = "INTERNAL_SERVER_ERROR"
+  val GatewayTimeout            = "GATEWAY_TIMEOUT"
+  val FunctionalError           = "FUNCTIONAL_ERROR"
+  val AcceptHeaderInvalid       = "ACCEPT_HEADER_INVALID"
+  val InvalidRequestJson        = "INVALID_REQUEST_JSON"
+  val InvalidTaxIdentifier      = "INVALID_TAX_IDENTIFIER"
+  val InvalidGuaranteeReference = "INVALID_GUARANTEE_REFERENCE"
+  val InvalidAccessCode         = "INVALID_ACCESS_CODE"
 }

--- a/app/models/errors/JsonParsingError.scala
+++ b/app/models/errors/JsonParsingError.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.errors
+
+import play.api.i18n.Messages
+import play.api.libs.json.JsPath
+import play.api.libs.json.Json
+import play.api.libs.json.JsonValidationError
+import play.api.libs.json.OWrites
+
+case class JsonParsingError(
+  message: String = "Invalid request JSON",
+  errors: Seq[(JsPath, Seq[JsonValidationError])]
+)
+
+object JsonParsingError {
+  private def toJsonPath(path: JsPath) =
+    path.path.foldLeft("$")((root, next) => root + next.toJsonString)
+
+  implicit def jsonParsingErrorWrites(implicit messages: Messages): OWrites[JsonParsingError] =
+    OWrites { error =>
+      Json.obj(
+        ErrorCode.FieldName -> ErrorCode.InvalidRequestJson,
+        "message"           -> error.message,
+        "errors" -> error.errors.foldLeft(Json.obj()) { case (obj, (path, errors)) =>
+          obj ++ Json.obj(toJsonPath(path) -> errors.map { error =>
+            messages(error.message, error.args: _*)
+          })
+        }
+      )
+    }
+}

--- a/app/services/BalanceRequestValidationService.scala
+++ b/app/services/BalanceRequestValidationService.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import cats.data.NonEmptyList
+import cats.data.Validated
+import cats.syntax.all._
+import models.errors.BadRequestError
+import models.errors.InvalidAccessCode
+import models.errors.InvalidGuaranteeReference
+import models.errors.InvalidTaxIdentifier
+import models.request.BalanceRequest
+import models.values.AccessCode
+import models.values.GuaranteeReference
+import models.values.TaxIdentifier
+
+import javax.inject.Inject
+
+class BalanceRequestValidationService @Inject() () {
+  type Validate[A] = Validated[NonEmptyList[BadRequestError], A]
+
+  def minLength(value: String, length: Int, error: Int => BadRequestError): Validate[Unit] =
+    Validated.condNel(value.length >= length, (), error(length))
+
+  def maxLength(value: String, length: Int, error: Int => BadRequestError): Validate[Unit] =
+    Validated.condNel(value.length <= length, (), error(length))
+
+  def exactLength(value: String, length: Int, error: Int => BadRequestError): Validate[Unit] =
+    Validated.condNel(value.length == length, (), error(length))
+
+  def alphanumeric(value: String, error: => BadRequestError): Validate[Unit] =
+    Validated.condNel(value.forall(_.isLetterOrDigit), (), error)
+
+  def validateTaxIdentifier(taxId: TaxIdentifier): Validate[Unit] =
+    (
+      maxLength(taxId.value, 17, InvalidTaxIdentifier.maxLength),
+      alphanumeric(taxId.value, InvalidTaxIdentifier.alphanumeric)
+    ).tupled.void
+
+  def validateGuaranteeReference(grn: GuaranteeReference): Validate[Unit] =
+    (
+      minLength(grn.value, 17, InvalidGuaranteeReference.minLength),
+      maxLength(grn.value, 24, InvalidGuaranteeReference.maxLength),
+      alphanumeric(grn.value, InvalidGuaranteeReference.alphanumeric)
+    ).tupled.void
+
+  def validateAccessCode(code: AccessCode): Validate[Unit] =
+    (
+      exactLength(code.value, 4, InvalidAccessCode.exactLength),
+      alphanumeric(code.value, InvalidAccessCode.alphanumeric)
+    ).tupled.void
+
+  def validate(request: BalanceRequest): Either[NonEmptyList[BadRequestError], BalanceRequest] =
+    (
+      validateTaxIdentifier(request.taxIdentifier),
+      validateGuaranteeReference(request.guaranteeReference),
+      validateAccessCode(request.accessCode)
+    ).tupled.as(request).toEither
+}

--- a/test/controllers/BalanceRequestControllerSpec.scala
+++ b/test/controllers/BalanceRequestControllerSpec.scala
@@ -46,6 +46,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers
 import play.api.test.Helpers._
 import services.BalanceRequestService
+import services.BalanceRequestValidationService
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -79,6 +80,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       appConfig,
       FakeAuthActionProvider,
       service,
+      new BalanceRequestValidationService,
       Helpers.stubControllerComponents(
         messagesApi = new DefaultMessagesApi(
           Map(
@@ -334,7 +336,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
         Json.obj(
           "code"    -> "INVALID_TAX_IDENTIFIER",
           "message" -> "Invalid tax identifier value",
-          "reason"  -> "Tax identifier value has a maximum length of 17 characters"
+          "reason"  -> "Tax identifier has a maximum length of 17 characters"
         )
       )
     )
@@ -362,12 +364,12 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
         Json.obj(
           "code"    -> "INVALID_TAX_IDENTIFIER",
           "message" -> "Invalid tax identifier value",
-          "reason"  -> "Tax identifier value has a maximum length of 17 characters"
+          "reason"  -> "Tax identifier has a maximum length of 17 characters"
         ),
         Json.obj(
           "code"    -> "INVALID_TAX_IDENTIFIER",
           "message" -> "Invalid tax identifier value",
-          "reason"  -> "Tax identifier value must be alphanumeric"
+          "reason"  -> "Tax identifier must be alphanumeric"
         )
       )
     )
@@ -395,7 +397,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
         Json.obj(
           "code"    -> "INVALID_GUARANTEE_REFERENCE",
           "message" -> "Invalid guarantee reference value",
-          "reason"  -> "Guarantee reference value has a maximum length of 24 characters"
+          "reason"  -> "Guarantee reference has a maximum length of 24 characters"
         )
       )
     )
@@ -423,7 +425,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
         Json.obj(
           "code"    -> "INVALID_GUARANTEE_REFERENCE",
           "message" -> "Invalid guarantee reference value",
-          "reason"  -> "Guarantee reference value has a minimum length of 17 characters"
+          "reason"  -> "Guarantee reference has a minimum length of 17 characters"
         )
       )
     )
@@ -451,12 +453,12 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
         Json.obj(
           "code"    -> "INVALID_GUARANTEE_REFERENCE",
           "message" -> "Invalid guarantee reference value",
-          "reason"  -> "Guarantee reference value has a maximum length of 24 characters"
+          "reason"  -> "Guarantee reference has a maximum length of 24 characters"
         ),
         Json.obj(
           "code"    -> "INVALID_GUARANTEE_REFERENCE",
           "message" -> "Invalid guarantee reference value",
-          "reason"  -> "Guarantee reference value must be alphanumeric"
+          "reason"  -> "Guarantee reference must be alphanumeric"
         )
       )
     )
@@ -484,7 +486,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
         Json.obj(
           "code"    -> "INVALID_ACCESS_CODE",
           "message" -> "Invalid access code value",
-          "reason"  -> "Access code value must be 4 characters in length"
+          "reason"  -> "Access code must be 4 characters in length"
         )
       )
     )
@@ -512,7 +514,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
         Json.obj(
           "code"    -> "INVALID_ACCESS_CODE",
           "message" -> "Invalid access code value",
-          "reason"  -> "Access code value must be 4 characters in length"
+          "reason"  -> "Access code must be 4 characters in length"
         )
       )
     )
@@ -540,12 +542,12 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
         Json.obj(
           "code"    -> "INVALID_ACCESS_CODE",
           "message" -> "Invalid access code value",
-          "reason"  -> "Access code value must be 4 characters in length"
+          "reason"  -> "Access code must be 4 characters in length"
         ),
         Json.obj(
           "code"    -> "INVALID_ACCESS_CODE",
           "message" -> "Invalid access code value",
-          "reason"  -> "Access code value must be alphanumeric"
+          "reason"  -> "Access code must be alphanumeric"
         )
       )
     )

--- a/test/controllers/BalanceRequestControllerSpec.scala
+++ b/test/controllers/BalanceRequestControllerSpec.scala
@@ -39,6 +39,8 @@ import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
 import play.api.http.ContentTypes
 import play.api.http.HeaderNames
+import play.api.i18n.DefaultMessagesApi
+import play.api.libs.json.JsString
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers
@@ -77,7 +79,30 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       appConfig,
       FakeAuthActionProvider,
       service,
-      Helpers.stubControllerComponents(),
+      Helpers.stubControllerComponents(
+        messagesApi = new DefaultMessagesApi(
+          Map(
+            "en" -> Map(
+              "error.expected.date"               -> "Date value expected",
+              "error.expected.date.isoformat"     -> "Iso date value expected",
+              "error.expected.time"               -> "Time value expected",
+              "error.expected.jsarray"            -> "Array value expected",
+              "error.expected.jsboolean"          -> "Boolean value expected",
+              "error.expected.jsnumber"           -> "Number value expected",
+              "error.expected.jsobject"           -> "Object value expected",
+              "error.expected.jsstring"           -> "String value expected",
+              "error.expected.jsnumberorjsstring" -> "String or number expected",
+              "error.expected.keypathnode"        -> "Node value expected",
+              "error.expected.uuid"               -> "UUID value expected",
+              "error.expected.validenumvalue"     -> "Valid enumeration value expected",
+              "error.expected.enumstring"         -> "String value expected",
+              "error.path.empty"                  -> "Empty path",
+              "error.path.missing"                -> "Missing path",
+              "error.path.result.multiple"        -> "Multiple results for the given path"
+            )
+          )
+        )
+      ),
       IORuntime.global,
       new FakeMetrics
     )
@@ -94,7 +119,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       BalanceRequestSuccess(BigDecimal("12345678.90"), CurrencyCode("GBP"))
 
     val request = FakeRequest()
-      .withBody(balanceRequest)
+      .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
     val result = controller(
@@ -121,7 +146,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       )
 
     val request = FakeRequest()
-      .withBody(balanceRequest)
+      .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
     val result = controller(
@@ -145,7 +170,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     val balanceRequestSuccess =
       BalanceRequestSuccess(BigDecimal("12345678.90"), CurrencyCode("GBP"))
 
-    val request = FakeRequest().withBody(balanceRequest)
+    val request = FakeRequest().withBody(Json.toJson(balanceRequest))
 
     val result = controller(
       sendRequestResponse = IO(Right(Right(balanceRequestSuccess)))
@@ -169,7 +194,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     val balanceId = BalanceId(UUID.randomUUID())
 
     val request = FakeRequest()
-      .withBody(balanceRequest)
+      .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
     val result = controller(
@@ -195,7 +220,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     val balanceId = BalanceId(UUID.randomUUID())
 
     val request = FakeRequest()
-      .withBody(balanceRequest)
+      .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
     val result = controller(
@@ -211,6 +236,350 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "return 400 when the request JSON is not a valid balance request" in {
+    val missingAccessCodeRequest = FakeRequest()
+      .withBody(
+        Json.obj(
+          "taxIdentifier"      -> "GB12345678900",
+          "guaranteeReference" -> "05DE3300BE0001067A001017"
+        )
+      )
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val missingAccessCodeResult = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(missingAccessCodeRequest)
+
+    status(missingAccessCodeResult) shouldBe BAD_REQUEST
+    contentType(missingAccessCodeResult) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(missingAccessCodeResult) shouldBe Json.obj(
+      "code"    -> "INVALID_REQUEST_JSON",
+      "message" -> "Invalid request JSON",
+      "errors" -> Json.obj(
+        "$.accessCode" -> Json.arr("Missing path")
+      )
+    )
+
+    val emptyObjectRequest = FakeRequest()
+      .withBody(Json.obj())
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val emptyObjectResult = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(emptyObjectRequest)
+
+    status(emptyObjectResult) shouldBe BAD_REQUEST
+    contentType(emptyObjectResult) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(emptyObjectResult) shouldBe Json.obj(
+      "code"    -> "INVALID_REQUEST_JSON",
+      "message" -> "Invalid request JSON",
+      "errors" -> Json.obj(
+        "$.taxIdentifier"      -> Json.arr("Missing path"),
+        "$.guaranteeReference" -> Json.arr("Missing path"),
+        "$.accessCode"         -> Json.arr("Missing path")
+      )
+    )
+
+    val wrongAccessCodeTypeRequest = FakeRequest()
+      .withBody(
+        Json.obj(
+          "taxIdentifier"      -> "GB12345678900",
+          "guaranteeReference" -> "05DE3300BE0001067A001017",
+          "accessCode"         -> 1234
+        )
+      )
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val wrongAccessCodeTypeResult = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(wrongAccessCodeTypeRequest)
+
+    status(wrongAccessCodeTypeResult) shouldBe BAD_REQUEST
+    contentType(wrongAccessCodeTypeResult) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(wrongAccessCodeTypeResult) shouldBe Json.obj(
+      "code"    -> "INVALID_REQUEST_JSON",
+      "message" -> "Invalid request JSON",
+      "errors" -> Json.obj(
+        "$.accessCode" -> Json.arr("String value expected")
+      )
+    )
+
+    val wrongRootElementRequest = FakeRequest()
+      .withBody(JsString(""))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val wrongRootElementResult = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(wrongRootElementRequest)
+
+    status(wrongRootElementResult) shouldBe BAD_REQUEST
+    contentType(wrongRootElementResult) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(wrongRootElementResult) shouldBe Json.obj(
+      "code"    -> "INVALID_REQUEST_JSON",
+      "message" -> "Invalid request JSON",
+      "errors" -> Json.obj(
+        "$.taxIdentifier"      -> Json.arr("Missing path"),
+        "$.guaranteeReference" -> Json.arr("Missing path"),
+        "$.accessCode"         -> Json.arr("Missing path")
+      )
+    )
+  }
+
+  it should "return 400 when the request contains a tax identifier that is too long" in {
+    val balanceRequest = BalanceRequest(
+      TaxIdentifier("GB123456789001920319203"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("1234")
+    )
+
+    val request = FakeRequest()
+      .withBody(Json.toJson(balanceRequest))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val result = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentType(result) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "BAD_REQUEST",
+      "message" -> "Bad request",
+      "errors" -> Json.arr(
+        Json.obj(
+          "code"    -> "INVALID_TAX_IDENTIFIER",
+          "message" -> "Invalid tax identifier value",
+          "reason"  -> "Tax identifier value has a maximum length of 17 characters"
+        )
+      )
+    )
+  }
+
+  it should "return 400 when the request contains a tax identifier which includes invalid characters" in {
+    val balanceRequest = BalanceRequest(
+      TaxIdentifier("GB123456789001920319203####"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("1234")
+    )
+
+    val request = FakeRequest()
+      .withBody(Json.toJson(balanceRequest))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val result = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentType(result) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "BAD_REQUEST",
+      "message" -> "Bad request",
+      "errors" -> Json.arr(
+        Json.obj(
+          "code"    -> "INVALID_TAX_IDENTIFIER",
+          "message" -> "Invalid tax identifier value",
+          "reason"  -> "Tax identifier value has a maximum length of 17 characters"
+        ),
+        Json.obj(
+          "code"    -> "INVALID_TAX_IDENTIFIER",
+          "message" -> "Invalid tax identifier value",
+          "reason"  -> "Tax identifier value must be alphanumeric"
+        )
+      )
+    )
+  }
+
+  it should "return 400 when the request contains a guarantee reference that is too long" in {
+    val balanceRequest = BalanceRequest(
+      TaxIdentifier("GB123456789001"),
+      GuaranteeReference("05DE3300BE0001067A00101723232"),
+      AccessCode("1234")
+    )
+
+    val request = FakeRequest()
+      .withBody(Json.toJson(balanceRequest))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val result = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentType(result) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "BAD_REQUEST",
+      "message" -> "Bad request",
+      "errors" -> Json.arr(
+        Json.obj(
+          "code"    -> "INVALID_GUARANTEE_REFERENCE",
+          "message" -> "Invalid guarantee reference value",
+          "reason"  -> "Guarantee reference value has a maximum length of 24 characters"
+        )
+      )
+    )
+  }
+
+  it should "return 400 when the request contains a guarantee reference that is too short" in {
+    val balanceRequest = BalanceRequest(
+      TaxIdentifier("GB123456789001"),
+      GuaranteeReference("05DE3300BE000106"),
+      AccessCode("1234")
+    )
+
+    val request = FakeRequest()
+      .withBody(Json.toJson(balanceRequest))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val result = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentType(result) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "BAD_REQUEST",
+      "message" -> "Bad request",
+      "errors" -> Json.arr(
+        Json.obj(
+          "code"    -> "INVALID_GUARANTEE_REFERENCE",
+          "message" -> "Invalid guarantee reference value",
+          "reason"  -> "Guarantee reference value has a minimum length of 17 characters"
+        )
+      )
+    )
+  }
+
+  it should "return 400 when the request contains a guarantee reference which includes invalid characters" in {
+    val balanceRequest = BalanceRequest(
+      TaxIdentifier("GB123456789001"),
+      GuaranteeReference("05DE3300B@€€01067A00101712931"),
+      AccessCode("1234")
+    )
+
+    val request = FakeRequest()
+      .withBody(Json.toJson(balanceRequest))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val result = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentType(result) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "BAD_REQUEST",
+      "message" -> "Bad request",
+      "errors" -> Json.arr(
+        Json.obj(
+          "code"    -> "INVALID_GUARANTEE_REFERENCE",
+          "message" -> "Invalid guarantee reference value",
+          "reason"  -> "Guarantee reference value has a maximum length of 24 characters"
+        ),
+        Json.obj(
+          "code"    -> "INVALID_GUARANTEE_REFERENCE",
+          "message" -> "Invalid guarantee reference value",
+          "reason"  -> "Guarantee reference value must be alphanumeric"
+        )
+      )
+    )
+  }
+
+  it should "return 400 when the request contains an access code that is too long" in {
+    val balanceRequest = BalanceRequest(
+      TaxIdentifier("GB123456789001"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("12345")
+    )
+
+    val request = FakeRequest()
+      .withBody(Json.toJson(balanceRequest))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val result = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentType(result) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "BAD_REQUEST",
+      "message" -> "Bad request",
+      "errors" -> Json.arr(
+        Json.obj(
+          "code"    -> "INVALID_ACCESS_CODE",
+          "message" -> "Invalid access code value",
+          "reason"  -> "Access code value must be 4 characters in length"
+        )
+      )
+    )
+  }
+
+  it should "return 400 when the request contains an access code that is too short" in {
+    val balanceRequest = BalanceRequest(
+      TaxIdentifier("GB123456789001"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("123")
+    )
+
+    val request = FakeRequest()
+      .withBody(Json.toJson(balanceRequest))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val result = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentType(result) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "BAD_REQUEST",
+      "message" -> "Bad request",
+      "errors" -> Json.arr(
+        Json.obj(
+          "code"    -> "INVALID_ACCESS_CODE",
+          "message" -> "Invalid access code value",
+          "reason"  -> "Access code value must be 4 characters in length"
+        )
+      )
+    )
+  }
+
+  it should "return 400 when the request contains an access code which includes invalid characters" in {
+    val balanceRequest = BalanceRequest(
+      TaxIdentifier("GB123456789001"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("1234#£@$#")
+    )
+
+    val request = FakeRequest()
+      .withBody(Json.toJson(balanceRequest))
+      .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
+
+    val result = controller(
+      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
+    ).submitBalanceRequest(request)
+
+    status(result) shouldBe BAD_REQUEST
+    contentType(result) shouldBe Some(ContentTypes.JSON)
+    contentAsJson(result) shouldBe Json.obj(
+      "code"    -> "BAD_REQUEST",
+      "message" -> "Bad request",
+      "errors" -> Json.arr(
+        Json.obj(
+          "code"    -> "INVALID_ACCESS_CODE",
+          "message" -> "Invalid access code value",
+          "reason"  -> "Access code value must be 4 characters in length"
+        ),
+        Json.obj(
+          "code"    -> "INVALID_ACCESS_CODE",
+          "message" -> "Invalid access code value",
+          "reason"  -> "Access code value must be alphanumeric"
+        )
+      )
+    )
+  }
+
   it should "return 500 when there is an upstream service error" in {
     val balanceRequest = BalanceRequest(
       TaxIdentifier("GB12345678900"),
@@ -219,7 +588,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     )
 
     val request = FakeRequest()
-      .withBody(balanceRequest)
+      .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
     val result = controller(
@@ -242,7 +611,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     )
 
     val request = FakeRequest()
-      .withBody(balanceRequest)
+      .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
     val result = controller(
@@ -265,7 +634,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     )
 
     val request = FakeRequest()
-      .withBody(balanceRequest)
+      .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
     val result = controller(

--- a/test/controllers/BalanceRequestControllerSpec.scala
+++ b/test/controllers/BalanceRequestControllerSpec.scala
@@ -167,14 +167,9 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       AccessCode("1234")
     )
 
-    val balanceRequestSuccess =
-      BalanceRequestSuccess(BigDecimal("12345678.90"), CurrencyCode("GBP"))
-
     val request = FakeRequest().withBody(Json.toJson(balanceRequest))
 
-    val result = controller(
-      sendRequestResponse = IO(Right(Right(balanceRequestSuccess)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe NOT_ACCEPTABLE
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -246,9 +241,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       )
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val missingAccessCodeResult = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(missingAccessCodeRequest)
+    val missingAccessCodeResult = controller().submitBalanceRequest(missingAccessCodeRequest)
 
     status(missingAccessCodeResult) shouldBe BAD_REQUEST
     contentType(missingAccessCodeResult) shouldBe Some(ContentTypes.JSON)
@@ -264,9 +257,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.obj())
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val emptyObjectResult = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(emptyObjectRequest)
+    val emptyObjectResult = controller().submitBalanceRequest(emptyObjectRequest)
 
     status(emptyObjectResult) shouldBe BAD_REQUEST
     contentType(emptyObjectResult) shouldBe Some(ContentTypes.JSON)
@@ -290,9 +281,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       )
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val wrongAccessCodeTypeResult = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(wrongAccessCodeTypeRequest)
+    val wrongAccessCodeTypeResult = controller().submitBalanceRequest(wrongAccessCodeTypeRequest)
 
     status(wrongAccessCodeTypeResult) shouldBe BAD_REQUEST
     contentType(wrongAccessCodeTypeResult) shouldBe Some(ContentTypes.JSON)
@@ -308,9 +297,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(JsString(""))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val wrongRootElementResult = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(wrongRootElementRequest)
+    val wrongRootElementResult = controller().submitBalanceRequest(wrongRootElementRequest)
 
     status(wrongRootElementResult) shouldBe BAD_REQUEST
     contentType(wrongRootElementResult) shouldBe Some(ContentTypes.JSON)
@@ -336,9 +323,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val result = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe BAD_REQUEST
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -366,9 +351,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val result = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe BAD_REQUEST
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -401,9 +384,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val result = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe BAD_REQUEST
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -431,9 +412,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val result = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe BAD_REQUEST
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -461,9 +440,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val result = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe BAD_REQUEST
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -496,9 +473,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val result = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe BAD_REQUEST
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -526,9 +501,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val result = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe BAD_REQUEST
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -556,9 +529,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       .withBody(Json.toJson(balanceRequest))
       .withHeaders(HeaderNames.ACCEPT -> "application/vnd.hmrc.1.0+json")
 
-    val result = controller(
-      sendRequestResponse = IO(Left(UpstreamErrorResponse("Argh!!!", 400)))
-    ).submitBalanceRequest(request)
+    val result = controller().submitBalanceRequest(request)
 
     status(result) shouldBe BAD_REQUEST
     contentType(result) shouldBe Some(ContentTypes.JSON)
@@ -736,23 +707,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     val uuid      = UUID.fromString("22b9899e-24ee-48e6-a189-97d1f45391c4")
     val balanceId = BalanceId(uuid)
 
-    val balanceRequestSuccess =
-      BalanceRequestSuccess(BigDecimal("12345678.90"), CurrencyCode("GBP"))
-
-    val pendingBalanceRequest = PendingBalanceRequest(
-      balanceId,
-      TaxIdentifier("GB12345678900"),
-      GuaranteeReference("05DE3300BE0001067A001017"),
-      OffsetDateTime.of(LocalDateTime.of(2021, 9, 14, 9, 52, 15), ZoneOffset.UTC).toInstant,
-      completedAt = Some(
-        OffsetDateTime.of(LocalDateTime.of(2021, 9, 14, 9, 53, 5), ZoneOffset.UTC).toInstant
-      ),
-      response = Some(balanceRequestSuccess)
-    )
-
-    val result = controller(
-      getRequestResponse = IO.some(Right(pendingBalanceRequest))
-    ).getBalanceRequest(balanceId)(FakeRequest())
+    val result = controller().getBalanceRequest(balanceId)(FakeRequest())
 
     status(result) shouldBe NOT_ACCEPTABLE
     contentType(result) shouldBe Some(ContentTypes.JSON)

--- a/test/controllers/ErrorLoggingSpec.scala
+++ b/test/controllers/ErrorLoggingSpec.scala
@@ -93,19 +93,6 @@ class ErrorLoggingSpec
       event.getThrowableProxy shouldBe null
   }
 
-  it should "log an error when there is a NotFoundError for a given BalanceId" in withLogAppender {
-    appender =>
-      val uuid      = UUID.fromString("22b9899e-24ee-48e6-a189-97d1f45391c4")
-      val balanceId = BalanceId(uuid)
-      val error     = BalanceRequestError.notFoundError(balanceId)
-      logServiceError("running tests", Left(error)).unsafeRunSync()
-      assert(!appender.list.isEmpty, appender.list)
-      val event = appender.list.get(0)
-      event.getLevel shouldBe Level.ERROR
-      event.getMessage shouldBe "Error when running tests: The balance request with ID 22b9899e-24ee-48e6-a189-97d1f45391c4 was not found"
-      event.getThrowableProxy shouldBe null
-  }
-
   it should "log an error when there is an UpstreamTimeoutError" in withLogAppender { appender =>
     val error = UpstreamTimeoutError()
     logServiceError("running tests", Left(error)).unsafeRunSync()
@@ -114,5 +101,14 @@ class ErrorLoggingSpec
     event.getLevel shouldBe Level.ERROR
     event.getMessage shouldBe "Timed out awaiting upstream response while running tests: Request timed out"
     event.getThrowableProxy shouldBe null
+  }
+
+  it should "not log anything when there is a NotFoundError for a given BalanceId" in withLogAppender {
+    appender =>
+      val uuid      = UUID.fromString("22b9899e-24ee-48e6-a189-97d1f45391c4")
+      val balanceId = BalanceId(uuid)
+      val error     = BalanceRequestError.notFoundError(balanceId)
+      logServiceError("running tests", Left(error)).unsafeRunSync()
+      assert(appender.list.isEmpty, appender.list)
   }
 }

--- a/test/services/BalanceRequestValidationServiceSpec.scala
+++ b/test/services/BalanceRequestValidationServiceSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import cats.data.NonEmptyList
+import models.errors.InvalidAccessCode
+import models.errors.InvalidGuaranteeReference
+import models.errors.InvalidTaxIdentifier
+import models.request.BalanceRequest
+import models.values.AccessCode
+import models.values.GuaranteeReference
+import models.values.TaxIdentifier
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class BalanceRequestValidationServiceSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  val validator = new BalanceRequestValidationService
+
+  "BalanceRequestValidationService.validate" should "return balance request when validation is successful" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB12345678900"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("1234")
+    )
+
+    validator.validate(request).value shouldBe request
+  }
+
+  it should "return an error when tax identifier is too long" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB1234567890012312312"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("1234")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.one(
+      InvalidTaxIdentifier.maxLength(17)
+    )
+  }
+
+  it should "return an error when tax identifier contains invalid characters" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB123456@8900#"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("1234")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.one(
+      InvalidTaxIdentifier.alphanumeric
+    )
+  }
+
+  it should "return an error when guarantee reference is too short" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB12345678900"),
+      GuaranteeReference("05DE3300BE000106"),
+      AccessCode("1234")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.one(
+      InvalidGuaranteeReference.minLength(17)
+    )
+  }
+
+  it should "return an error when guarantee reference is too long" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB12345678900"),
+      GuaranteeReference("05DE3300BE0001067A0010178"),
+      AccessCode("1234")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.one(
+      InvalidGuaranteeReference.maxLength(24)
+    )
+  }
+
+  it should "return an error when guarantee reference contains invalid characters" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB12345678900"),
+      GuaranteeReference("05DE33@#¢E0001067A001017"),
+      AccessCode("1234")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.one(
+      InvalidGuaranteeReference.alphanumeric
+    )
+  }
+
+  it should "return an error when access code is too short" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB12345678900"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("234")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.one(
+      InvalidAccessCode.exactLength(4)
+    )
+  }
+
+  it should "return an error when access code is too long" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB12345678900"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("12345678")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.one(
+      InvalidAccessCode.exactLength(4)
+    )
+  }
+
+  it should "return an error when access code contains invalid characters" in {
+    val request = BalanceRequest(
+      TaxIdentifier("GB12345678900"),
+      GuaranteeReference("05DE3300BE0001067A001017"),
+      AccessCode("123]")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.one(
+      InvalidAccessCode.alphanumeric
+    )
+  }
+
+  it should "return multiple errors when there are several problems" in {
+    val request = BalanceRequest(
+      TaxIdentifier("########################"),
+      GuaranteeReference("##############"),
+      AccessCode("#")
+    )
+
+    validator.validate(request).left.value shouldBe NonEmptyList.of(
+      InvalidTaxIdentifier.maxLength(17),
+      InvalidTaxIdentifier.alphanumeric,
+      InvalidGuaranteeReference.minLength(17),
+      InvalidGuaranteeReference.alphanumeric,
+      InvalidAccessCode.exactLength(4),
+      InvalidAccessCode.alphanumeric
+    )
+  }
+}


### PR DESCRIPTION
This ensures that the user can't enter things that would later cause us to produce schema-invalid XML in the backend service.