### PR TITLE
CGBA-96: Add rate limited request audit events

### DIFF
--- a/app/models/audit/AuditEvent.scala
+++ b/app/models/audit/AuditEvent.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.audit
+
+import models.request.AuthenticatedRequest
+import models.request.BalanceRequest
+import models.values.AccessCode
+import models.values.GuaranteeReference
+import models.values.InternalId
+import models.values.TaxIdentifier
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+
+sealed abstract class AuditEvent extends Product with Serializable
+
+case class RateLimitedRequestEvent(
+  userInternalId: InternalId,
+  taxIdentifier: TaxIdentifier,
+  guaranteeReference: GuaranteeReference,
+  accessCode: AccessCode
+) extends AuditEvent
+
+object RateLimitedRequestEvent {
+  implicit val rateLimitedRequestEvertWrites: OWrites[RateLimitedRequestEvent] =
+    Json.writes[RateLimitedRequestEvent]
+
+  def fromRequest(
+    request: AuthenticatedRequest[JsValue],
+    balanceRequest: BalanceRequest
+  ): RateLimitedRequestEvent =
+    RateLimitedRequestEvent(
+      request.internalId,
+      balanceRequest.taxIdentifier,
+      balanceRequest.guaranteeReference,
+      balanceRequest.accessCode
+    )
+}

--- a/app/models/audit/AuditEventType.scala
+++ b/app/models/audit/AuditEventType.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.audit
+
+sealed abstract class AuditEventType(val name: String) extends Product with Serializable
+
+object AuditEventType {
+  case object RateLimitedRequest extends AuditEventType("RateLimitedRequest")
+}

--- a/app/services/AuditService.scala
+++ b/app/services/AuditService.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import cats.effect.IO
+import com.google.inject.ImplementedBy
+import models.audit.AuditEventType
+import models.audit.RateLimitedRequestEvent
+import models.request.AuthenticatedRequest
+import models.request.BalanceRequest
+import play.api.libs.json.JsValue
+import runtime.IOFutures
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@ImplementedBy(classOf[AuditServiceImpl])
+trait AuditService {
+  def auditRateLimitedRequest(
+    request: AuthenticatedRequest[JsValue],
+    balanceRequest: BalanceRequest
+  )(implicit
+    hc: HeaderCarrier
+  ): IO[Unit]
+}
+
+@Singleton
+class AuditServiceImpl @Inject() (connector: AuditConnector) extends AuditService with IOFutures {
+
+  override def auditRateLimitedRequest(
+    request: AuthenticatedRequest[JsValue],
+    balanceRequest: BalanceRequest
+  )(implicit
+    hc: HeaderCarrier
+  ): IO[Unit] = {
+    val rateLimitedRequestEvent = RateLimitedRequestEvent.fromRequest(request, balanceRequest)
+
+    IO.executionContext.flatMap { implicit ec =>
+      IO {
+        connector.sendExplicitAudit[RateLimitedRequestEvent](
+          AuditEventType.RateLimitedRequest.name,
+          rateLimitedRequestEvent
+        )
+      }
+    }
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -27,7 +27,7 @@ object AppDependencies {
     "uk.gov.hmrc"         %% "bootstrap-test-play-28"  % bootstrapVersion,
     "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28" % hmrcMongoVersion,
     "com.typesafe.akka"   %% "akka-testkit"            % PlayVersion.akkaVersion,
-    "org.mockito"         %% "mockito-scala"           % "1.16.42",
+    "org.mockito"         %% "mockito-scala-scalatest" % "1.16.46",
     "com.vladsch.flexmark" % "flexmark-all"            % "0.62.2"
   ).map(_ % s"$Test, $IntegrationTest")
 }

--- a/test/controllers/BalanceRequestControllerSpec.scala
+++ b/test/controllers/BalanceRequestControllerSpec.scala
@@ -47,6 +47,7 @@ import play.api.test.Helpers
 import play.api.test.Helpers._
 import services.BalanceRequestService
 import services.BalanceRequestValidationService
+import services.FakeAuditService
 import services.FakeBalanceRequestLockService
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -83,6 +84,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       FakeAuthActionProvider,
       service,
       FakeBalanceRequestLockService(isLockedOutResponse),
+      new FakeAuditService,
       new BalanceRequestValidationService,
       Helpers.stubControllerComponents(
         messagesApi = new DefaultMessagesApi(

--- a/test/models/audit/AuditEventTypeSpec.scala
+++ b/test/models/audit/AuditEventTypeSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.audit
+
+import models.request.AuthenticatedRequest
+import models.request.BalanceRequest
+import models.values.AccessCode
+import models.values.GuaranteeReference
+import models.values.InternalId
+import models.values.TaxIdentifier
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.libs.json.JsNull
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+
+class AuditEventTypeSpec extends AnyFlatSpec {
+
+  val internalId         = InternalId("ABC123")
+  val taxIdentifier      = TaxIdentifier("GB12345678900")
+  val guaranteeReference = GuaranteeReference("05DE3300BE0001067A001017")
+  val accessCode         = AccessCode("1234")
+
+  "RateLimitedRequestEvent" should "serialise to JSON" in {
+    val authenticatedRequest: AuthenticatedRequest[JsValue] =
+      AuthenticatedRequest(
+        FakeRequest().withBody(JsNull), // we don't care here as we have a separate balance request
+        internalId
+      )
+
+    val balanceRequest = BalanceRequest(taxIdentifier, guaranteeReference, accessCode)
+
+    val event = RateLimitedRequestEvent.fromRequest(authenticatedRequest, balanceRequest)
+
+    Json.toJsObject(event) shouldBe Json.obj(
+      "userInternalId"     -> "ABC123",
+      "taxIdentifier"      -> "GB12345678900",
+      "guaranteeReference" -> "05DE3300BE0001067A001017",
+      "accessCode"         -> "1234"
+    )
+  }
+
+}

--- a/test/services/AuditServiceSpec.scala
+++ b/test/services/AuditServiceSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import cats.effect.unsafe.implicits.global
+import models.audit.RateLimitedRequestEvent
+import models.request.AuthenticatedRequest
+import models.request.BalanceRequest
+import models.values.AccessCode
+import models.values.GuaranteeReference
+import models.values.InternalId
+import models.values.TaxIdentifier
+import org.mockito.scalatest.AsyncIdiomaticMockito
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.JsValue
+import play.api.libs.json.Writes
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+
+import scala.concurrent.ExecutionContext
+
+class AuditServiceSpec
+  extends AsyncFlatSpec
+  with Matchers
+  with AsyncIdiomaticMockito
+  with BeforeAndAfterEach {
+
+  val auditConnector = mock[AuditConnector]
+  val auditService   = new AuditServiceImpl(auditConnector)
+
+  implicit val hc = HeaderCarrier()
+
+  val internalId         = InternalId("ABC123")
+  val taxIdentifier      = TaxIdentifier("GB12345678900")
+  val guaranteeReference = GuaranteeReference("05DE3300BE0001067A001017")
+  val accessCode         = AccessCode("1234")
+
+  override protected def beforeEach(): Unit =
+    reset(auditConnector)
+
+  "AuditService.auditRateLimitedRequest" should "audit rate limited requests" in {
+
+    // Given this request with a specific internal ID
+    val authenticatedRequest = mock[AuthenticatedRequest[JsValue]]
+    authenticatedRequest.internalId returns internalId
+
+    val balanceRequest = BalanceRequest(taxIdentifier, guaranteeReference, accessCode)
+
+    // When an audit request is made
+    auditService.auditRateLimitedRequest(authenticatedRequest, balanceRequest)
+
+    // Then the connector should be called with this event
+    val expectedEvent =
+      RateLimitedRequestEvent(internalId, taxIdentifier, guaranteeReference, accessCode)
+
+    auditService
+      .auditRateLimitedRequest(authenticatedRequest, balanceRequest)
+      .map { _ =>
+        auditConnector.sendExplicitAudit[RateLimitedRequestEvent](
+          "RateLimitedRequest",
+          expectedEvent
+        )(
+          any[HeaderCarrier],
+          any[ExecutionContext],
+          any[Writes[RateLimitedRequestEvent]]
+        ) wasCalled once
+      }
+      .unsafeToFuture()
+  }
+
+}

--- a/test/services/FakeAuditService.scala
+++ b/test/services/FakeAuditService.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import cats.effect.IO
+import models.request.AuthenticatedRequest
+import models.request.BalanceRequest
+import play.api.libs.json.JsValue
+import uk.gov.hmrc.http.HeaderCarrier
+
+class FakeAuditService extends AuditService {
+  override def auditRateLimitedRequest(
+    request: AuthenticatedRequest[JsValue],
+    balanceRequest: BalanceRequest
+  )(implicit
+    hc: HeaderCarrier
+  ): IO[Unit] = IO.unit
+}


### PR DESCRIPTION
Added an audit event for when rate limiting is hit by a user. Currently stores the basic information about the request - unsure as to whether anything else might be helpful here.

See also https://github.com/hmrc/transit-movements-guarantee-balance/pull/25 which is part of the same ticket.

* Replaced "mockito-scala" dependency with "mockito-scala-scalatest", updated to 1.16.46 to allow testing of the audit service (and is in line with `transit-movements-guarantee-balance`)