### PR TITLE
Preserve logging MDC information where possible

### DIFF
--- a/app/connectors/BalanceRequestConnector.scala
+++ b/app/connectors/BalanceRequestConnector.scala
@@ -43,6 +43,7 @@ import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import javax.inject.Inject
 import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -62,8 +63,9 @@ trait BalanceRequestConnector {
 class BalanceRequestConnectorImpl @Inject() (
   appConfig: AppConfig,
   http: HttpClient,
-  val metrics: Metrics
-)(implicit val materializer: Materializer)
+  val metrics: Metrics,
+  val materializer: Materializer
+)(implicit ec: ExecutionContext)
   extends BalanceRequestConnector
   with IOFutures
   with IOMetrics
@@ -93,7 +95,7 @@ class BalanceRequestConnectorImpl @Inject() (
     hc: HeaderCarrier
   ): IO[SendRequestResponse] =
     withMetricsTimerResponse(SendRequest) {
-      IO.runFuture { implicit ec =>
+      IO.runFuture {
         circuitBreaker.withCircuitBreaker(
           {
             val url = appConfig.backendUrl.addPathPart("balances")
@@ -127,7 +129,7 @@ class BalanceRequestConnectorImpl @Inject() (
     hc: HeaderCarrier
   ): IO[GetRequestResponse] =
     withMetricsTimer(GetRequest) { timer =>
-      val runGet = IO.runFuture { implicit ec =>
+      val runGet = IO.runFuture {
         circuitBreaker.withCircuitBreaker(
           {
             val url = appConfig.backendUrl.addPathPart("balances").addPathPart(balanceId.value)

--- a/app/connectors/CircuitBreakers.scala
+++ b/app/connectors/CircuitBreakers.scala
@@ -21,6 +21,7 @@ import akka.stream.Materializer
 import config.CircuitBreakerConfig
 import logging.Logging
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 trait CircuitBreakers { self: Logging =>
@@ -29,7 +30,7 @@ trait CircuitBreakers { self: Logging =>
 
   private val clazz = getClass.getSimpleName
 
-  lazy val circuitBreaker = new CircuitBreaker(
+  def circuitBreaker(implicit ec: ExecutionContext) = new CircuitBreaker(
     scheduler = materializer.system.scheduler,
     maxFailures = circuitBreakerConfig.maxFailures,
     callTimeout = circuitBreakerConfig.callTimeout,
@@ -37,7 +38,7 @@ trait CircuitBreakers { self: Logging =>
     maxResetTimeout = circuitBreakerConfig.maxResetTimeout,
     exponentialBackoffFactor = circuitBreakerConfig.exponentialBackoffFactor,
     randomFactor = circuitBreakerConfig.randomFactor
-  )(materializer.executionContext)
+  )
     .onOpen(slf4jLogger.error(s"Circuit breaker for ${clazz} opening due to failures"))
     .onHalfOpen(slf4jLogger.warn(s"Circuit breaker for ${clazz} resetting after failures"))
     .onClose {

--- a/app/controllers/ErrorLogging.scala
+++ b/app/controllers/ErrorLogging.scala
@@ -19,9 +19,12 @@ package controllers
 import cats.effect.IO
 import logging.Logging
 import models.errors._
+import uk.gov.hmrc.http.HeaderCarrier
 
 trait ErrorLogging { self: Logging =>
-  def logServiceError[A](action: String, result: Either[BalanceRequestError, A]): IO[Unit] = {
+  def logServiceError[A](action: String, result: Either[BalanceRequestError, A])(implicit
+    hc: HeaderCarrier
+  ): IO[Unit] = {
     result.fold(
       {
         case UpstreamServiceError(_, cause) =>

--- a/app/logging/Logging.scala
+++ b/app/logging/Logging.scala
@@ -19,8 +19,11 @@ package logging
 import cats.effect.IO
 import org.slf4j.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import uk.gov.hmrc.http.HeaderCarrier
 
 trait Logging {
-  val logger      = Slf4jLogger.getLoggerFromClass[IO](getClass())
-  val slf4jLogger = LoggerFactory.getLogger(getClass())
+  val slf4jLogger         = LoggerFactory.getLogger(getClass())
+  private val basicLogger = Slf4jLogger.getLoggerFromSlf4j[IO](slf4jLogger)
+
+  def logger(implicit hc: HeaderCarrier) = basicLogger.addContext(hc.mdcData)
 }

--- a/app/runtime/IOFutures.scala
+++ b/app/runtime/IOFutures.scala
@@ -17,13 +17,15 @@
 package runtime
 
 import cats.effect.IO
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.logging.Mdc
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 trait IOFutures {
   implicit class IOCompanionFutureOps(io: IO.type) {
-    def runFuture[A](f: ExecutionContext => Future[A]): IO[A] =
-      IO.fromFuture { IO.executionContext.map(f) }
+    def runFuture[A](f: => Future[A])(implicit ec: ExecutionContext, hc: HeaderCarrier): IO[A] =
+      IO.fromFuture { IO(Mdc.withMdc(f, Mdc.mdcData ++ hc.mdcData)) }
   }
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -49,7 +49,7 @@
 
     <logger name="application" level="DEBUG"/>
 
-    <logger name="connector" level="TRACE">
+    <logger name="connector" level="TRACE" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/it/connectors/BalanceRequestConnectorSpec.scala
+++ b/it/connectors/BalanceRequestConnectorSpec.scala
@@ -36,7 +36,9 @@ import play.api.http.HeaderNames
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.RequestId
 import uk.gov.hmrc.http.UpstreamErrorResponse._
+import uk.gov.hmrc.http.{HeaderNames => HmrcHeaderNames}
 
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -55,7 +57,9 @@ class BalanceRequestConnectorSpec
     "microservice.services.transit-movements-guarantee-balance.port"
   )
 
-  implicit val hc = HeaderCarrier()
+  implicit val hc = HeaderCarrier(
+    requestId = Some(RequestId("6790293d-a688-4d85-9cd4-c8e24e163179"))
+  )
 
   val requestJson = Json.obj(
     "taxIdentifier"      -> "GB12345678900",
@@ -75,6 +79,7 @@ class BalanceRequestConnectorSpec
       post(urlEqualTo("/transit-movements-guarantee-balance/balances"))
         .withHeader(HeaderNames.ACCEPT, equalTo(ContentTypes.JSON))
         .withHeader(HeaderNames.CONTENT_TYPE, equalTo(ContentTypes.JSON))
+        .withHeader(HmrcHeaderNames.xRequestId, equalTo("6790293d-a688-4d85-9cd4-c8e24e163179"))
         .withHeader("Channel", equalTo("api"))
         .withRequestBody(equalToJson(Json.stringify(requestJson)))
         .willReturn(
@@ -111,6 +116,7 @@ class BalanceRequestConnectorSpec
         .withHeader(HeaderNames.ACCEPT, equalTo(ContentTypes.JSON))
         .withHeader(HeaderNames.CONTENT_TYPE, equalTo(ContentTypes.JSON))
         .withHeader("Channel", equalTo("api"))
+        .withHeader(HmrcHeaderNames.xRequestId, equalTo("6790293d-a688-4d85-9cd4-c8e24e163179"))
         .withRequestBody(equalToJson(Json.stringify(requestJson)))
         .willReturn(
           aResponse()
@@ -177,6 +183,7 @@ class BalanceRequestConnectorSpec
       get(urlEqualTo(s"/transit-movements-guarantee-balance/balances/${balanceId.value}"))
         .withHeader(HeaderNames.ACCEPT, equalTo(ContentTypes.JSON))
         .withHeader(HeaderNames.CONTENT_TYPE, equalTo(ContentTypes.JSON))
+        .withHeader(HmrcHeaderNames.xRequestId, equalTo("6790293d-a688-4d85-9cd4-c8e24e163179"))
         .withHeader("Channel", equalTo("api"))
         .willReturn(
           aResponse()
@@ -229,6 +236,7 @@ class BalanceRequestConnectorSpec
       get(urlEqualTo(s"/transit-movements-guarantee-balance/balances/${balanceId.value}"))
         .withHeader(HeaderNames.ACCEPT, equalTo(ContentTypes.JSON))
         .withHeader(HeaderNames.CONTENT_TYPE, equalTo(ContentTypes.JSON))
+        .withHeader(HmrcHeaderNames.xRequestId, equalTo("6790293d-a688-4d85-9cd4-c8e24e163179"))
         .withHeader("Channel", equalTo("api"))
         .willReturn(aResponse().withStatus(NOT_FOUND))
     )
@@ -250,6 +258,7 @@ class BalanceRequestConnectorSpec
       get(urlEqualTo(s"/transit-movements-guarantee-balance/balances/${balanceId.value}"))
         .withHeader(HeaderNames.ACCEPT, equalTo(ContentTypes.JSON))
         .withHeader(HeaderNames.CONTENT_TYPE, equalTo(ContentTypes.JSON))
+        .withHeader(HmrcHeaderNames.xRequestId, equalTo("6790293d-a688-4d85-9cd4-c8e24e163179"))
         .withHeader("Channel", equalTo("api"))
         .willReturn(aResponse().withStatus(METHOD_NOT_ALLOWED))
     )
@@ -273,6 +282,7 @@ class BalanceRequestConnectorSpec
       get(urlEqualTo(s"/transit-movements-guarantee-balance/balances/${balanceId.value}"))
         .withHeader(HeaderNames.ACCEPT, equalTo(ContentTypes.JSON))
         .withHeader(HeaderNames.CONTENT_TYPE, equalTo(ContentTypes.JSON))
+        .withHeader(HmrcHeaderNames.xRequestId, equalTo("6790293d-a688-4d85-9cd4-c8e24e163179"))
         .withHeader("Channel", equalTo("api"))
         .willReturn(aResponse().withStatus(GATEWAY_TIMEOUT))
     )

--- a/test/controllers/ErrorLoggingSpec.scala
+++ b/test/controllers/ErrorLoggingSpec.scala
@@ -31,6 +31,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.slf4j.LoggerFactory
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import java.util.UUID
@@ -41,6 +42,8 @@ class ErrorLoggingSpec
   with ScalaCheckPropertyChecks
   with Logging
   with ErrorLogging {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
 
   def withLogAppender[A](test: ListAppender[ILoggingEvent] => A) = {
     val slf4jLogger   = LoggerFactory.getLogger(getClass())

--- a/test/metrics/IOMetricsSpec.scala
+++ b/test/metrics/IOMetricsSpec.scala
@@ -33,10 +33,12 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers
 import play.api.test.Helpers._
 import runtime.IOFutures
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import java.util.concurrent.CancellationException
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -47,25 +49,28 @@ class IOMetricsSpec
   with IdiomaticMockito
   with ArgumentMatchersSugar {
 
+  implicit val hc: HeaderCarrier    = HeaderCarrier()
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
   class IOMetricsConnector(val metrics: Metrics) extends IOFutures with IOMetrics {
     def okHttpCall =
       withMetricsTimerResponse("connector-ok") {
-        IO.runFuture { _ => Future.successful(Right(1)) }
+        IO.runFuture { Future.successful(Right(1)) }
       }
 
     def clientErrorHttpCall =
       withMetricsTimerResponse("connector-client-error") {
-        IO.runFuture { _ => Future.successful(Left(UpstreamErrorResponse("Arghhh!!!", 400))) }
+        IO.runFuture { Future.successful(Left(UpstreamErrorResponse("Arghhh!!!", 400))) }
       }
 
     def serverErrorHttpCall =
       withMetricsTimerResponse("connector-server-error") {
-        IO.runFuture { _ => Future.successful(Left(UpstreamErrorResponse("Kaboom!!!", 502))) }
+        IO.runFuture { Future.successful(Left(UpstreamErrorResponse("Kaboom!!!", 502))) }
       }
 
     def unhandledExceptionHttpCall =
       withMetricsTimerResponse("connector-unhandled-exception") {
-        IO.runFuture { _ => Future.failed(new RuntimeException) }
+        IO.runFuture { Future.failed(new RuntimeException) }
       }
 
     def cancelledHttpCall =

--- a/test/runtime/IOFuturesSpec.scala
+++ b/test/runtime/IOFuturesSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.test.DefaultAwaitTimeout
 import play.api.test.FutureAwaits
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -36,11 +37,12 @@ class IOFuturesSpec
   with IOFutures {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit val hc: HeaderCarrier    = HeaderCarrier()
 
   "IO.runFuture" should "run successful Futures to identical result" in forAll {
     (fn: (String => Int), str: String) =>
       val viaIO =
-        IO.runFuture { implicit ec => Future(str)(ec).map(fn)(ec) }.unsafeToFuture()
+        IO.runFuture { Future(str)(ec).map(fn)(ec) }.unsafeToFuture()
 
       val viaFuture =
         Future(str).map(fn)
@@ -57,7 +59,7 @@ class IOFuturesSpec
     val exc = new RuntimeException
 
     val viaIO =
-      IO.runFuture { _ => Future(num).map[Int](_ => throw exc) }.unsafeToFuture()
+      IO.runFuture { Future(num).map[Int](_ => throw exc) }.unsafeToFuture()
 
     val viaFuture =
       Future(num).map[Int](_ => throw exc)

--- a/test/services/BalanceRequestLockServiceSpec.scala
+++ b/test/services/BalanceRequestLockServiceSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.CurrentTimestampSupport
 import uk.gov.hmrc.mongo.lock.Lock
 import uk.gov.hmrc.mongo.lock.MongoLockRepository
@@ -40,7 +41,8 @@ class BalanceRequestLockServiceSpec
   with ScalaFutures
   with DefaultPlayMongoRepositorySupport[Lock] {
 
-  implicit val ec = ExecutionContext.global
+  implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit val hc: HeaderCarrier    = HeaderCarrier()
 
   def mkAppConfig(config: Configuration) = {
     val servicesConfig = new ServicesConfig(config)

--- a/test/services/FakeBalanceRequestLockService.scala
+++ b/test/services/FakeBalanceRequestLockService.scala
@@ -19,9 +19,12 @@ package services
 import cats.effect.IO
 import models.values.GuaranteeReference
 import models.values.InternalId
+import uk.gov.hmrc.http.HeaderCarrier
 
 case class FakeBalanceRequestLockService(isLockedOutResponse: IO[Boolean])
   extends BalanceRequestLockService {
-  override def isLockedOut(grn: GuaranteeReference, internalId: InternalId): IO[Boolean] =
+  override def isLockedOut(grn: GuaranteeReference, internalId: InternalId)(implicit
+    hc: HeaderCarrier
+  ): IO[Boolean] =
     isLockedOutResponse
 }


### PR DESCRIPTION
HMRC's integration with Kibana makes use of a JSON logging encoder which encodes the SLF4J MDC into the log event in order to record request tracing information like the request and session ID. 

This doesn't work very well in multithreaded scenarios because the MDC is thread-local data and frameworks like akka and cats-effect shift work between threads pretty frequently, meaning that MDC data intermittently goes missing for certain log statements depending upon how work is allocated to the underlying worker threads (see e.g. https://github.com/playframework/playframework/issues/7458).

We can fix this in `log4cats` logging calls by using the structured logging API that it offers to add the request information to the base context for the logger, which fixes the problem in our own code, but this still presents difficulties when we hand off to other libraries like internal HMRC ones and the Akka circuit breaker. The best we can do there is to add the MDC info we're interested in before handing off to the library call.