### PR TITLE
Interpret GMS query limit error as a rate limiting error

### DIFF
--- a/app/controllers/BalanceRequestController.scala
+++ b/app/controllers/BalanceRequestController.scala
@@ -148,7 +148,7 @@ class BalanceRequestController @Inject() (
               .isLockedOut(balanceRequest.guaranteeReference, request.internalId)
               .ifM(
                 ifTrue = for {
-                  result <- IO(TooManyRequests(Json.toJson(TooManyRequestsError())))
+                  result <- IO(TooManyRequests(Json.toJson(TooManyRequestsError.apiRateLimit())))
                   _      <- auditService.auditRateLimitedRequest(request, balanceRequest)
                 } yield result,
                 ifFalse = {
@@ -161,7 +161,7 @@ class BalanceRequestController @Inject() (
 
                       case Right(Right(error @ BalanceRequestFunctionalError(_)))
                           if hasQueryLimitError(error) =>
-                        TooManyRequests(Json.toJson(TooManyRequestsError()))
+                        TooManyRequests(Json.toJson(TooManyRequestsError.gmsQueryLimit()))
 
                       case Right(Right(error @ BalanceRequestFunctionalError(_))) =>
                         BadRequest(Json.toJson(PostBalanceRequestFunctionalErrorResponse(error)))

--- a/app/models/errors/RateLimitReason.scala
+++ b/app/models/errors/RateLimitReason.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.errors
+
+object RateLimitReason {
+  val FieldName     = "reason"
+  val ApiRateLimit  = "API_RATE_LIMIT"
+  val GmsQueryLimit = "GMS_QUERY_LIMIT"
+}

--- a/app/models/values/ErrorPointer.scala
+++ b/app/models/values/ErrorPointer.scala
@@ -14,20 +14,16 @@
  * limitations under the License.
  */
 
-package models.backend.errors
+package models.values
 
-import models.values.ErrorPointer
-import models.values.ErrorType
+import play.api.libs.json.Format
 import play.api.libs.json.Json
-import play.api.libs.json.OFormat
 
-case class FunctionalError(
-  errorType: ErrorType,
-  errorPointer: ErrorPointer,
-  errorReason: Option[String]
-)
+case class ErrorPointer(value: String) extends AnyVal
 
-object FunctionalError {
-  implicit lazy val functionalErrorFormat: OFormat[FunctionalError] =
-    Json.format[FunctionalError]
+object ErrorPointer {
+  implicit val errorPointerFormat: Format[ErrorPointer] =
+    Json.valueFormat[ErrorPointer]
+
+  val RequesterEori = ErrorPointer("RC1.TIN")
 }

--- a/app/models/values/ErrorType.scala
+++ b/app/models/values/ErrorType.scala
@@ -24,4 +24,6 @@ case class ErrorType(value: Int) extends AnyVal
 object ErrorType {
   implicit val errorTypeFormat: Format[ErrorType] =
     Json.valueFormat[ErrorType]
+
+  val DuplicateDetected = ErrorType(26)
 }

--- a/public/api/conf/1.0/application.raml
+++ b/public/api/conf/1.0/application.raml
@@ -97,6 +97,17 @@ traits:
                   }]
                 }
               }
+      429:
+        body:
+          application/json:
+            type: !include schemas/post-balance-request-rate-limited-response-schema.json
+            description: The request was rate limited, either due to API rate limiting or the guarantee management system query limit
+            example: |
+              {
+                "code": "TOO_MANY_REQUESTS",
+                "reason": "GMS_QUERY_LIMIT",
+                "message": "Too many requests"
+              }
 
   /{balanceId}:
     uriParameters:

--- a/public/api/conf/1.0/schemas/post-balance-request-rate-limited-response-schema.json
+++ b/public/api/conf/1.0/schemas/post-balance-request-rate-limited-response-schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "#/post-balance-request-rate-limited-response-schema.json",
+    "description": "A response indicating that the request was rate limited",
+    "type": "object",
+    "required": [
+        "code",
+        "message",
+        "reason"
+    ],
+    "properties": {
+        "code": {
+            "enum": [
+                "TOO_MANY_REQUESTS"
+            ]
+        },
+        "message": {
+            "description": "The description of the error",
+            "type": "string"
+        },
+        "reason": {
+            "enum": [
+                "API_RATE_LIMIT",
+                "GMS_QUERY_LIMIT"
+            ]
+        }
+    }
+}

--- a/test/controllers/BalanceRequestControllerSpec.scala
+++ b/test/controllers/BalanceRequestControllerSpec.scala
@@ -258,6 +258,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     contentType(result) shouldBe Some(ContentTypes.JSON)
     contentAsJson(result) shouldBe Json.obj(
       "code"    -> "TOO_MANY_REQUESTS",
+      "reason"  -> "API_RATE_LIMIT",
       "message" -> "Too many requests"
     )
   }
@@ -288,6 +289,7 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
     contentType(result) shouldBe Some(ContentTypes.JSON)
     contentAsJson(result) shouldBe Json.obj(
       "code"    -> "TOO_MANY_REQUESTS",
+      "reason"  -> "GMS_QUERY_LIMIT",
       "message" -> "Too many requests"
     )
   }

--- a/test/models/response/ResponseFormatsSpec.scala
+++ b/test/models/response/ResponseFormatsSpec.scala
@@ -71,7 +71,7 @@ class ResponseFormatsSpec extends AnyFlatSpec with Matchers {
   it should "write a functional error POST response" in {
     val balanceRequestFunctionalError =
       BalanceRequestFunctionalError(
-        NonEmptyList.one(FunctionalError(ErrorType(14), "Foo.Bar(1).Baz", None))
+        NonEmptyList.one(FunctionalError(ErrorType(14), ErrorPointer("Foo.Bar(1).Baz"), None))
       )
     val postResponse =
       PostBalanceRequestFunctionalErrorResponse(balanceRequestFunctionalError)
@@ -169,7 +169,7 @@ class ResponseFormatsSpec extends AnyFlatSpec with Matchers {
 
     val balanceRequestFunctionalError =
       BalanceRequestFunctionalError(
-        NonEmptyList.one(FunctionalError(ErrorType(14), "Foo.Bar(1).Baz", None))
+        NonEmptyList.one(FunctionalError(ErrorType(14), ErrorPointer("Foo.Bar(1).Baz"), None))
       )
 
     val pendingBalanceRequest = PendingBalanceRequest(


### PR DESCRIPTION
One of the things that came up during E2E testing - GMS has a query limit per "requester EORI". 

In our implementation of the service the user can choose this value so the query limit does not really provide any useful security properties, but we should be able to handle this error scenario and indicate what has happened to the user. 

I suggest that we handle this no differently to the usual rate limiting and return a 429.